### PR TITLE
Add configuration to save command in history

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,11 @@
                     "default": false,
                     "description": "Clear terminal before run?"
                 },
+                "runInTerminal.saveCommandInHistory": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Save command in history?"
+                },
                 "runInTerminal.commands": {
                     "type": "array",
                     "items": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -125,7 +125,7 @@ class Cmd {
     );
     command = command.replace(/\${cwd}/g, `${process.cwd()}`);
 
-    command = this.config.get('clearBeforeRun') ? ` clear; ${command}` : ` ${command}`;
+    command = this.config.get('clearBeforeRun') ? ` clear; ${command}` : command;
     // replace environment variables ${env.Name}
     command = command.replace(/\${env\.([^}]+)}/g, (sub, envName) => {
       return process.env[envName];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -125,7 +125,12 @@ class Cmd {
     );
     command = command.replace(/\${cwd}/g, `${process.cwd()}`);
 
-    command = this.config.get('clearBeforeRun') ? ` clear; ${command}` : command;
+    if(this.config.get('saveCommandInHistory')) {
+      command = this.config.get('clearBeforeRun') ? `clear; ${command}` : command;
+    } else {
+      command = this.config.get('clearBeforeRun') ? ` clear; ${command}` : ` ${command}`;
+    }
+
     // replace environment variables ${env.Name}
     command = command.replace(/\${env\.([^}]+)}/g, (sub, envName) => {
       return process.env[envName];


### PR DESCRIPTION
This PR closes #2.

This PR adds a new configuration option to save the commands in the system history, disabled by default to keep to current behavior. Enabling this would effectively remove the starting space character, as reported in #2.