### PR TITLE
fix: can't kill terminal

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,7 @@ class Term {
 
       // if user closes the terminal, delete our reference:
       vscode.window.onDidCloseTerminal(event => {
-        if (Term._term() && event.name === Term.termName) {
+        if (Term._term().processId == event.processId && event.name === Term.termName) {
           Term.term = undefined;
         }
       });


### PR DESCRIPTION
should fix the issue https://github.com/kortina/run-in-terminal/issues/34

as I understand bug happens because only name checked, so everything is screwed when you got more than one terminal called 'run-in-terminal', which could happen when you reopening editor and everytime use the extension it will open up new terminal and not reuse old one.

