### PR TITLE
add workspaceName

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ You can use the following substitution tokens in `cmd` strings:
 - `${line}`
 - `${relativeFile}`
 - `${workspaceRoot}`
+- `${workspaceName}`
 
 ## Commands
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -120,6 +120,7 @@ class Cmd {
     command = command.replace(/\${relativeFile}/g, relativeFile);
     command = command.replace(/\${file}/g, `${this.editor.document.fileName}`);
     command = command.replace(/\${workspaceRoot}/g, `${vscode.workspace.rootPath}`);
+    command = command.replace(/\${workspaceName}/g, `${vscode.workspace.name}`);
     command = command.replace(
       /\${fileBasename}/g,
       `${path.basename(this.editor.document.fileName)}`


### PR DESCRIPTION
A small change for commands that need to pass the name of the workspace without the path to it